### PR TITLE
feat(api): add chat streaming endpoint

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,26 @@
+import { streamText, UIMessage, convertToModelMessages } from 'ai';
+
+// Allow streaming responses up to 30 seconds
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const {
+    messages,
+    model,
+    webSearch,
+  }: { messages: UIMessage[]; model: string; webSearch: boolean } =
+    await req.json();
+
+  const result = streamText({
+    model: webSearch ? 'perplexity/sonar' : model,
+    messages: convertToModelMessages(messages),
+    system:
+      'You are a helpful assistant that can answer questions and help with tasks',
+  });
+
+  // send sources and reasoning back to the client
+  return result.toUIMessageStreamResponse({
+    sendSources: true,
+    sendReasoning: true,
+  });
+}


### PR DESCRIPTION

This pull request introduces a new POST endpoint in `app/api/chat/route.ts` to handle chat requests, supporting both standard and web search-enabled AI models. It enables streaming responses with sources and reasoning included, and sets a 30-second maximum duration for responses.

**New chat endpoint and streaming improvements:**

* Added a POST handler in `app/api/chat/route.ts` that streams AI-generated responses, supporting both standard models and a web search model (`perplexity/sonar`) based on the `webSearch` flag.
* Configured the endpoint to send sources and reasoning back to the client with each streamed response, enhancing transparency and usability.
* Set a maximum streaming response duration of 30 seconds to prevent long-running requests.